### PR TITLE
Implement point rendering on top of dummy terrain

### DIFF
--- a/Assets/Scenes/Dummy Terrain.unity
+++ b/Assets/Scenes/Dummy Terrain.unity
@@ -159,6 +159,7 @@ MonoBehaviour:
   - serializedVersion: 2
     rgba: 4294967295
   contourThickness: 0.15
+  timescale: 1
   minZ: 0
   maxZ: 0
 --- !u!33 &1072510806
@@ -381,7 +382,7 @@ Camera:
   near clip plane: 0.3
   far clip plane: 1000
   field of view: 60
-  orthographic: 1
+  orthographic: 0
   orthographic size: 240
   m_Depth: -1
   m_CullingMask:
@@ -404,14 +405,14 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1640075998}
-  m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
-  m_LocalPosition: {x: 0, y: 240, z: 300}
+  m_LocalRotation: {x: -0, y: 0.95437044, z: 0.2986255, w: 0}
+  m_LocalPosition: {x: 0, y: -155, z: 300}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1267841866}
   m_Father: {fileID: 1639521133}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 0}
+  m_LocalEulerAnglesHint: {x: -34.75, y: 180.00002, z: 0}
 --- !u!1 &1915785659
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Sandbox/Sandbox.cs
+++ b/Assets/Scripts/Sandbox/Sandbox.cs
@@ -52,7 +52,7 @@ public class Sandbox : MonoBehaviour
 
         if (Input.GetKey(KeyCode.W))
         {
-            terrainmesh.transform.position += Vector3.forward * 100f * Time.smoothDeltaTime;\
+            terrainmesh.transform.position += Vector3.forward * 100f * Time.smoothDeltaTime;
             WriteConfig();
         }
 

--- a/Assets/Scripts/Sandbox/Terrain/DummyMesh.cs
+++ b/Assets/Scripts/Sandbox/Terrain/DummyMesh.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 public class DummyMesh : TerrainMesh
 {
@@ -6,12 +7,7 @@ public class DummyMesh : TerrainMesh
     public int Height = 480;
 
     public Color32 contourColor = Color.black;
-    public Color32[] heightmapColors = {
-        Color.blue,
-        Color.green,
-        Color.red,
-        Color.white
-    };
+    public Color32[] heightmapColors = { Color.blue, Color.green, Color.red, Color.white };
 
     [Range(0, 1)]
     public float contourThickness = .15f;
@@ -27,7 +23,15 @@ public class DummyMesh : TerrainMesh
     public float timescale = 1f;
 
     [SerializeField]
-    float minZ, maxZ;
+    float minZ,
+        maxZ;
+
+    public int pointSize = 5;
+    public Color32 pointColor = Color.black;
+    List<Point> points;
+
+    List<Line> lines;
+    List<Polygon> polygons;
 
     void Start()
     {
@@ -35,6 +39,11 @@ public class DummyMesh : TerrainMesh
         mesh.indexFormat = UnityEngine.Rendering.IndexFormat.UInt32;
 
         transform.position = new Vector3(-Width / 2f, -Height / 2f, 0);
+
+        points = new List<Point>();
+        points.Add(new Point(new Vector3(0.1f, 0.2f, 0.5f), pointSize, pointColor, "circle"));
+        lines = new List<Line>();
+        polygons = new List<Polygon>();
 
         vertices = new Vector3[Width * Height];
         normals = new Vector3[Width * Height];
@@ -89,8 +98,14 @@ public class DummyMesh : TerrainMesh
             for (int x = 0; x < Width; x++)
             {
                 int i = x + y * Width;
+
                 float z = // (new Vector2(x, y) - new Vector2(Width / 2f, Height / 2f)).magnitude*0.01f +
-                          Mathf.PerlinNoise(10f * x / (float)Width + timestep, 10f * y / (float)Height + timestep) * (float)Width / 10f;
+                    Mathf.PerlinNoise(
+                        10f * x / (float)Width + timestep,
+                        10f * y / (float)Height + timestep
+                    )
+                    * (float)Width
+                    / 10f;
 
                 minZ = Mathf.Min(z, minZ);
                 maxZ = Mathf.Max(z, maxZ);
@@ -99,6 +114,8 @@ public class DummyMesh : TerrainMesh
                 colors[i] = getVertexColor(z);
             }
         }
+        // updateMarkers();             // to be implemented
+        drawShapes(ref colors);
 
         mesh.vertices = vertices;
         mesh.colors32 = colors;
@@ -108,12 +125,46 @@ public class DummyMesh : TerrainMesh
         timestep += timescale * Time.smoothDeltaTime / 2f;
     }
 
+    void drawShapes(ref Color32[] colors)
+    {
+        // colors[i] = drawAllPolygons();
+        // colors[i] = drawAllLines();
+        drawAllPoints(ref colors);
+    }
+
+    void drawAllPolygons(ref Color32[] colors) { }
+
+    void drawAllLines(ref Color32[] colors) { }
+
+    void drawAllPoints(ref Color32[] colors)
+    {
+        foreach (var point in points)
+            renderPoint(point, ref colors);
+    }
+
+    void renderPoint(Point point, ref Color32[] colors)
+    {
+        int x = (int)(point.location.x * Width);    // assuming location of points will range from 0 - 1.
+        int y = (int)(point.location.y * Height);  
+        int i = x + y * Width; 
+
+        colors[i] = point.color;
+
+        if (point.type == "circle")
+        {
+            for (int ry = -point.size; ry < point.size; ry++)
+                for (int rx = -point.size; rx < point.size; rx++)
+                    if ((rx * rx) + (ry * ry) <= point.size * point.size)
+                        colors[(x + rx) + (y + ry) * Width] = point.color;
+        }
+    }
+
     Color32 getVertexColor(float z)
     {
         int nColors = heightmapColors.Length;
         float heightRange = maxZ - minZ;
         float relativeZ = (z - minZ);
-        float normalizedZ = relativeZ / heightRange - 0.0001f;  // Replace with heightRange/1000f?
+        float normalizedZ = relativeZ / heightRange - 0.0001f; // Replace with heightRange/1000f?
         float colorIndexFloat = normalizedZ * nColors;
         int colorIndexInt = (int)colorIndexFloat;
 
@@ -127,9 +178,10 @@ public class DummyMesh : TerrainMesh
             float decimalVal = colorIndexFloat - colorIndexInt;
 
             if (
-                decimalVal < contourThickness &&    // Check if we lie in the contour region
-                colorIndexInt < nColors             // Do not try to contour near top region
-               )
+                decimalVal < contourThickness
+                && // Check if we lie in the contour region
+                colorIndexInt < nColors // Do not try to contour near top region
+            )
                 return contourColor;
         }
 
@@ -139,9 +191,13 @@ public class DummyMesh : TerrainMesh
 
     Color32 getVertexColorFromGradient(float z)
     {
-        float normalizedZ = (z - minZ) / (maxZ - minZ + 0.0001f);    // = [0, 1)
-        float colorIndexFloat = normalizedZ * (heightmapColors.Length-1);
+        float normalizedZ = (z - minZ) / (maxZ - minZ + 0.0001f); // = [0, 1)
+        float colorIndexFloat = normalizedZ * (heightmapColors.Length - 1);
         int colorIndex = (int)colorIndexFloat;
-        return Color.Lerp(heightmapColors[colorIndex], heightmapColors[colorIndex + 1], colorIndexFloat - colorIndex);
+        return Color.Lerp(
+            heightmapColors[colorIndex],
+            heightmapColors[colorIndex + 1],
+            colorIndexFloat - colorIndex
+        );
     }
 }

--- a/Assets/Scripts/Sandbox/Utils.meta
+++ b/Assets/Scripts/Sandbox/Utils.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: cf59b2ab82dc7e14cbea991e9ed31dea
+folderAsset: yes
+timeCreated: 1706353722
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sandbox/Utils/Line.cs
+++ b/Assets/Scripts/Sandbox/Utils/Line.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Line {
+	string type;
+	Vector3[] handles;
+}

--- a/Assets/Scripts/Sandbox/Utils/Line.cs.meta
+++ b/Assets/Scripts/Sandbox/Utils/Line.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 3f1915fd354127e41b26bc5e76f5d02c
+timeCreated: 1706353736
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sandbox/Utils/Point.cs
+++ b/Assets/Scripts/Sandbox/Utils/Point.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Point {
+	public Vector3 location;
+	public int size;
+	public Color32 color;
+	public string type;
+
+	public Point (Vector3 location, int size, Color32 color, string type) {
+		this.location = location;
+		this.size = size;
+		this.color = color;
+		this.type = type;
+	}
+}

--- a/Assets/Scripts/Sandbox/Utils/Point.cs.meta
+++ b/Assets/Scripts/Sandbox/Utils/Point.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 04e06d00b12626b4192c423d94bbdebf
+timeCreated: 1706359570
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Sandbox/Utils/Polygon.cs
+++ b/Assets/Scripts/Sandbox/Utils/Polygon.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class Polygon {
+	string type;
+	Vector3[] handles;
+}

--- a/Assets/Scripts/Sandbox/Utils/Polygon.cs.meta
+++ b/Assets/Scripts/Sandbox/Utils/Polygon.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: b3f3fb0ad7bb77d4d803a1aaa2211ab9
+timeCreated: 1706353810
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders.meta
+++ b/Assets/Shaders.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 1cbb0b78c36ccb742be75228188a41c9
+folderAsset: yes
+timeCreated: 1706168446
+licenseType: Free
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Shaders/HeightmapGradient.shader.meta
+++ b/Assets/Shaders/HeightmapGradient.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 7efa469b1a70c764580f5bfaf29364ce
+timeCreated: 1706168461
+licenseType: Free
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Input 
- `List` of `point` objects

### An object of the `Point` class needs:
- `location` (Vector3)
- `size` (int) : denoting the size of the marker
- `color` (Color32) : color of the marker
- `type` (string) : shape of the marker, currently circle is implemented. This attribute exists for extending the usage of point class for different shaped points as well.

## Output 
Point rendered on the desired location of the desired size, shape and color on top of the dummy terrain.